### PR TITLE
Drop the MODULE[ModuleScienceExperiment] from SK_TIROS

### DIFF
--- a/System/ScienceRework/ScienceDefs/MeteorologicalExperiments.cfg
+++ b/System/ScienceRework/ScienceDefs/MeteorologicalExperiments.cfg
@@ -562,4 +562,6 @@ EXPERIMENT_DEFINITION:NEEDS[FeatureScience]
 		%experimentLength = #$@KERBALISM_GROUP_SETTINGS/SK_MeteorologicalExperiments/sss_basicWeatherImaging/duration$
 		%experimentSize = #$@KERBALISM_GROUP_SETTINGS/SK_MeteorologicalExperiments/sss_basicWeatherImaging/size$
 	}
+
+	!MODULE:HAS[#SSS_bd_weather[True],~name[Experiment]]	{}
 }


### PR DESCRIPTION
SkyhawkKerbalism defines a corresponding Kerbalism `MODULE[Experiment]`, but leaves the non-Kerbalism `MODULE[ModuleScienceExperiment]` in place as well. Fix it by using the same line to remove it as for the other weather experiments.