### PR TITLE
Fix version file URL property

### DIFF
--- a/SkyhawkKerbalism.version
+++ b/SkyhawkKerbalism.version
@@ -1,6 +1,6 @@
 {
   "NAME": "SkyhawkKerbalism",
-  "URL": "https://github.com/CessnaSkyhawk/SkyhawkKerbalism",
+  "URL": "https://github.com/CessnaSkyhawk/SkyhawkKerbalism/raw/main/SkyhawkKerbalism.version",
   "DOWNLOAD": "https://github.com/CessnaSkyhawk/SkyhawkKerbalism/releases",
   "CHANGE_LOG_URL": "https://github.com/CessnaSkyhawk/SkyhawkKerbalism",
   "VERSION": {"MAJOR": 1, "MINOR": 0, "PATCH": 2, "BUILD": 0},


### PR DESCRIPTION
Hi @CessnaSkyhawk!

The version file's URL property is supposed to point to a "remote version file", an online copy of the version file that you can update to affect the mod's compatibility after release (or notify users of available updates if they have KSP-AVC installed). Currently it points to the repo; this pull request fixes it.

Noticed while working on KSP-CKAN/NetKAN#9379.

Cheers!
